### PR TITLE
Add spectrogram panel with LPC formant extraction

### DIFF
--- a/rtva/app.py
+++ b/rtva/app.py
@@ -1,12 +1,16 @@
-from PyQt6.QtWidgets import QApplication
 import sys
+
+from PyQt6.QtWidgets import QApplication
+
 from rtva.ui.main_window import MainWindow
+
 
 def main():
     app = QApplication(sys.argv)
     w = MainWindow()
     w.show()
     sys.exit(app.exec())
+
 
 if __name__ == "__main__":
     main()

--- a/rtva/audio.py
+++ b/rtva/audio.py
@@ -1,9 +1,12 @@
-import sounddevice as sd
-import numpy as np
 from queue import Queue
+
+import numpy as np
+import sounddevice as sd
+
 
 class AudioStream:
     """Mic → ライブフレーム供給。hopごとに非同期で取り出せる"""
+
     def __init__(self, sr=44100, blocksize=1024):
         self.sr = sr
         self.blocksize = blocksize
@@ -35,6 +38,7 @@ class AudioStream:
     def read(self):
         """ブロックを1つ返す（float32, shape=(blocksize,)）"""
         return self.q.get()
+
 
 def hann(n: int):
     return 0.5 - 0.5 * np.cos(2 * np.pi * np.arange(n) / n)

--- a/rtva/dsp/lpc.py
+++ b/rtva/dsp/lpc.py
@@ -1,5 +1,105 @@
+"""Linear predictive coding helpers for formant analysis."""
+
+from __future__ import annotations
+
 import numpy as np
+from numpy.typing import NDArray
 from scipy.signal import lfilter
 
-def pre_emphasis(x: np.ndarray, coef=0.97):
-    return lfilter([1, -coef], [1], x)
+
+def pre_emphasis(
+    x: NDArray[np.float64] | NDArray[np.float32],
+    coef: float = 0.97,
+) -> NDArray[np.float64]:
+    """Apply a simple pre-emphasis filter to the signal."""
+
+    return lfilter([1.0, -coef], [1.0], x).astype(np.float64, copy=False)
+
+
+def _levinson_durbin(r: NDArray[np.float64], order: int) -> tuple[NDArray[np.float64], float]:
+    """Solve the Yule-Walker equations via Levinson-Durbin recursion."""
+
+    a = np.zeros(order + 1, dtype=np.float64)
+    e = r[0]
+    if e <= 0.0:
+        return a, float(e)
+
+    a[0] = 1.0
+    for i in range(1, order + 1):
+        acc = r[i]
+        for j in range(1, i):
+            acc += a[j] * r[i - j]
+        k = -acc / e
+        a_prev = a.copy()
+        a[i] = k
+        for j in range(1, i):
+            a[j] = a_prev[j] + k * a_prev[i - j]
+        e *= 1.0 - k * k
+        if e <= 0.0:
+            e = 1e-9
+            break
+    return a, float(e)
+
+
+def lpc_formants(
+    frame: NDArray[np.float32] | NDArray[np.float64],
+    sr: int,
+    order: int = 14,
+    fmax: int = 5000,
+) -> tuple[float, float, float]:
+    """Estimate the first three formants in Hz using LPC analysis.
+
+    Args:
+        frame: Single analysis frame (windowed) of audio samples.
+        sr: Sampling rate in Hz.
+        order: LPC order (usually 2 * expected number of formants + 2).
+        fmax: Upper frequency limit for reported formants.
+
+    Returns:
+        Tuple of (F1, F2, F3) in Hz. Missing formants are reported as 0.0.
+    """
+
+    if frame.size == 0 or sr <= 0:
+        return 0.0, 0.0, 0.0
+
+    order = int(order)
+    if order < 2:
+        return 0.0, 0.0, 0.0
+
+    x = np.asarray(frame, dtype=np.float64)
+    if not np.any(x):
+        return 0.0, 0.0, 0.0
+
+    x = pre_emphasis(x, 0.97)
+    x -= np.mean(x)
+    if not np.any(np.abs(x) > 0):
+        return 0.0, 0.0, 0.0
+
+    n = len(x)
+    if order >= n:
+        order = n - 1
+    if order < 2:
+        return 0.0, 0.0, 0.0
+
+    autocorr = np.correlate(x, x, mode="full")
+    autocorr = autocorr[n - 1 : n + order]
+    if autocorr[0] <= 0.0:
+        return 0.0, 0.0, 0.0
+
+    a, _ = _levinson_durbin(autocorr, order)
+    if not np.any(a):
+        return 0.0, 0.0, 0.0
+
+    roots = np.roots(a)
+    roots = roots[np.imag(roots) >= 0.0]
+    ang = np.arctan2(np.imag(roots), np.real(roots))
+    freqs = ang * (sr / (2.0 * np.pi))
+    freqs = freqs[(freqs > 0.0) & (freqs < fmax)]
+    if freqs.size == 0:
+        return 0.0, 0.0, 0.0
+
+    freqs.sort()
+    f1 = float(freqs[0]) if freqs.size > 0 else 0.0
+    f2 = float(freqs[1]) if freqs.size > 1 else 0.0
+    f3 = float(freqs[2]) if freqs.size > 2 else 0.0
+    return f1, f2, f3

--- a/rtva/dsp/pitch.py
+++ b/rtva/dsp/pitch.py
@@ -3,6 +3,7 @@
 # 優先: Praat (parselmouth) / 失敗時: 自前オートコリレーションにフォールバック。
 
 from __future__ import annotations
+
 import numpy as np
 
 try:
@@ -11,7 +12,9 @@ except Exception:  # parselmouthが無い・動かない場合も考慮
     parselmouth = None
 
 
-def _pitch_parselmouth(frame: np.ndarray, sr: int, fmin: float = 75.0, fmax: float = 350.0) -> float:
+def _pitch_parselmouth(
+    frame: np.ndarray, sr: int, fmin: float = 75.0, fmax: float = 350.0
+) -> float:
     """Praat(autocorrelation)でF0を推定。中央値でロバスト化。"""
     snd = parselmouth.Sound(frame.astype(float), sampling_frequency=sr)
     # time_step=0 は自動。autocorrelation method が既定。

--- a/rtva/dsp/spectrum.py
+++ b/rtva/dsp/spectrum.py
@@ -1,0 +1,39 @@
+"""Spectral analysis helpers for RTVA."""
+
+from __future__ import annotations
+
+import numpy as np
+from numpy.typing import NDArray
+
+
+def stft_mag_db(
+    frame: NDArray[np.float32] | NDArray[np.float64],
+    sr: int,
+    n_fft: int | None = None,
+    floor_db: float = -120.0,
+) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
+    """Return magnitude spectrum in dB for a single frame.
+
+    The result is normalised so that the maximum magnitude in the frame is 0 dB.
+    Values below ``floor_db`` are clipped to that floor to stabilise the colour map.
+    """
+
+    x = np.asarray(frame, dtype=np.float64)
+    if x.size == 0 or sr <= 0:
+        return np.array([], dtype=np.float64), np.array([], dtype=np.float64)
+
+    if n_fft is None:
+        n_fft = int(2 ** np.ceil(np.log2(len(x))))
+    n_fft = max(n_fft, len(x))
+
+    spectrum = np.fft.rfft(x, n=n_fft)
+    magnitude = np.abs(spectrum)
+    if not np.any(magnitude):
+        freqs = np.fft.rfftfreq(n_fft, 1.0 / sr)
+        return freqs, np.full_like(freqs, floor_db, dtype=np.float64)
+
+    mag_db = 20.0 * np.log10(np.maximum(magnitude, 1e-12))
+    mag_db -= mag_db.max()
+    mag_db = np.maximum(mag_db, floor_db)
+    freqs = np.fft.rfftfreq(n_fft, 1.0 / sr)
+    return freqs, mag_db

--- a/rtva/tests/conftest.py
+++ b/rtva/tests/conftest.py
@@ -1,0 +1,10 @@
+"""Configure path so tests can import the package without installation."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))

--- a/rtva/tests/test_lpc.py
+++ b/rtva/tests/test_lpc.py
@@ -1,0 +1,32 @@
+import numpy as np
+import pytest
+from scipy.signal import lfilter
+
+from rtva.dsp.lpc import lpc_formants
+
+
+def synth_vowel(formants, bandwidths, sr, duration):
+    rng = np.random.default_rng(0)
+    n_samples = int(sr * duration)
+    src = rng.normal(0, 1, n_samples)
+    y = src
+    for f, bw in zip(formants, bandwidths):
+        r = np.exp(-np.pi * bw / sr)
+        theta = 2 * np.pi * f / sr
+        a = np.array([1, -2 * r * np.cos(theta), r**2])
+        b = np.array([1 - r])
+        y = lfilter(b, a, y)
+    return y.astype(np.float32)
+
+
+def test_lpc_formants_tracks_resonances():
+    sr = 16000
+    formants = [500, 1500, 2500]
+    bandwidths = [60, 90, 150]
+    frame = synth_vowel(formants, bandwidths, sr, duration=0.05)
+
+    f1, f2, f3 = lpc_formants(frame * np.hanning(len(frame)), sr, order=14, fmax=4000)
+
+    assert f1 == pytest.approx(formants[0], rel=0.2)
+    assert f2 == pytest.approx(formants[1], rel=0.2)
+    assert f3 == pytest.approx(formants[2], rel=0.2)

--- a/rtva/tests/test_signals.py
+++ b/rtva/tests/test_signals.py
@@ -1,9 +1,11 @@
 import numpy as np
+
 from rtva.dsp.pitch import yin_f0
+
 
 def test_yin_sine_440():
     sr = 44100
-    t = np.arange(0, 0.1, 1/sr)
-    x = np.sin(2*np.pi*440*t).astype(np.float32)
+    t = np.arange(0, 0.1, 1 / sr)
+    x = np.sin(2 * np.pi * 440 * t).astype(np.float32)
     f0 = yin_f0(x, sr, 75, 900)
     assert abs(f0 - 440) < 5

--- a/rtva/ui/panels.py
+++ b/rtva/ui/panels.py
@@ -1,10 +1,14 @@
-from PyQt6.QtWidgets import QWidget, QVBoxLayout, QLabel, QHBoxLayout
-from PyQt6.QtCore import Qt
-import pyqtgraph as pg
+from __future__ import annotations
+
 import numpy as np
+import pyqtgraph as pg
+from PyQt6.QtCore import QRectF, Qt
+from PyQt6.QtWidgets import QHBoxLayout, QLabel, QVBoxLayout, QWidget
+
 
 class PitchPanel(QWidget):
     """F0数値＋直近時系列（10秒くらい）"""
+
     def __init__(self, timespan_sec=10, sr_hop=100):
         super().__init__()
         self.setLayout(QVBoxLayout())
@@ -18,8 +22,8 @@ class PitchPanel(QWidget):
 
         self.plot = pg.PlotWidget()
         self.plot.setYRange(60, 600)  # 目安
-        self.plot.setLabel('left', 'F0 (Hz)')
-        self.plot.setLabel('bottom', 'time (s)')
+        self.plot.setLabel("left", "F0 (Hz)")
+        self.plot.setLabel("bottom", "time (s)")
         self.curve = self.plot.plot(pen=pg.mkPen(width=2))
         self.layout().addWidget(self.plot)
 
@@ -33,8 +37,8 @@ class PitchPanel(QWidget):
         # 円環→直列へ
         start = self.index - self.capacity
         idx = np.arange(start, self.index)
-        y = self.buf.take(np.arange(self.capacity), mode='wrap')
-        x = np.linspace(-len(y)/100, 0, len(y))  # 100Hz更新想定
+        y = self.buf.take(np.arange(self.capacity), mode="wrap")
+        x = np.linspace(-len(y) / 100, 0, len(y))  # 100Hz更新想定
         self.curve.setData(x, y)
         if f0_hz > 0:
             self.value_label.setText(f"F0: {f0_hz:6.1f} Hz")
@@ -47,18 +51,88 @@ class PitchPanel(QWidget):
         else:
             self.stability_label.setText(f"±cent: {cents_std:4.1f}")
 
+
 class SpectroPanel(QWidget):
-    """後でスペクトログラム/フォルマントを載せる土台（今はプレースホルダ）"""
-    def __init__(self):
+    """Spectrogram heatmap with formant overlays."""
+
+    def __init__(self, timespan_sec: float = 6.0, hop_s: float = 0.01, fmax: float = 8000.0):
         super().__init__()
         self.setLayout(QVBoxLayout())
-        self.layout().addWidget(QLabel("Spectrogram (coming soon)"))
+
+        self.timespan_sec = float(timespan_sec)
+        self.hop_s = max(float(hop_s), 1e-3)
+        self.fmax = float(fmax)
+        self.time_bins = max(4, int(np.ceil(self.timespan_sec / self.hop_s)))
+        self.freqs: np.ndarray | None = None
+        self.spec_buf: np.ndarray | None = None
+        self.formant_hist: np.ndarray | None = None
+        self.time_axis = np.linspace(-self.timespan_sec, 0.0, self.time_bins)
+
+        self.plot = pg.PlotWidget()
+        self.plot.setLabel("left", "Frequency", units="Hz")
+        self.plot.setLabel("bottom", "Time", units="s")
+        self.plot.setYRange(0, self.fmax)
+        self.plot.setXRange(-self.timespan_sec, 0.0)
+        self.plot.showGrid(x=False, y=True, alpha=0.2)
+
+        self.image = pg.ImageItem()
+        cmap = pg.colormap.get("magma")
+        self.image.setLookupTable(cmap.getLookupTable())
+        self.plot.addItem(self.image)
+
+        colors = ["#66c2a5", "#fc8d62", "#8da0cb"]
+        self.formant_curves = [
+            self.plot.plot(pen=pg.mkPen(color=colors[i], width=2)) for i in range(3)
+        ]
+
+        self.layout().addWidget(self.plot)
+
+    def _ensure_buffers(self, freqs: np.ndarray):
+        mask = freqs <= self.fmax
+        sel = freqs[mask]
+        if sel.size == 0:
+            return
+        if self.freqs is None or self.freqs.size != sel.size:
+            self.freqs = sel
+            self.spec_buf = np.full((sel.size, self.time_bins), -120.0, dtype=np.float32)
+            self.formant_hist = np.full((3, self.time_bins), np.nan, dtype=np.float32)
+            self.image.setImage(np.flipud(self.spec_buf), autoLevels=False)
+            self.image.setRect(QRectF(-self.timespan_sec, 0.0, self.timespan_sec, self.freqs[-1]))
+            self.plot.setYRange(0, min(self.fmax, float(self.freqs[-1])))
+
+    def update_spectrogram(self, freqs: np.ndarray, mag_db: np.ndarray):
+        if freqs.size == 0 or mag_db.size == 0:
+            return
+        self._ensure_buffers(freqs)
+        if self.freqs is None or self.spec_buf is None:
+            return
+        mask = freqs <= self.freqs[-1]
+        sel = mag_db[mask][: self.freqs.size]
+        if sel.size != self.freqs.size:
+            return
+        self.spec_buf[:, :-1] = self.spec_buf[:, 1:]
+        self.spec_buf[:, -1] = sel
+        self.image.setImage(np.flipud(self.spec_buf), autoLevels=False)
+
+    def update_formants(self, f1: float, f2: float, f3: float):
+        if self.formant_hist is None:
+            self.formant_hist = np.full((3, self.time_bins), np.nan, dtype=np.float32)
+        self.formant_hist[:, :-1] = self.formant_hist[:, 1:]
+        self.formant_hist[:, -1] = [
+            f1 if f1 > 0 else np.nan,
+            f2 if f2 > 0 else np.nan,
+            f3 if f3 > 0 else np.nan,
+        ]
+        for idx, curve in enumerate(self.formant_curves):
+            curve.setData(self.time_axis, self.formant_hist[idx])
+
 
 class HarmonicsPanel(QWidget):
     def __init__(self):
         super().__init__()
         self.setLayout(QVBoxLayout())
         self.layout().addWidget(QLabel("H1–H2 (coming soon)"))
+
 
 class CPPPanel(QWidget):
     def __init__(self):


### PR DESCRIPTION
## Summary
- add LPC-based formant estimation helper and STFT magnitude conversion helpers
- implement the spectrogram panel with scrolling display and formant overlays
- update the main window loop and add a regression test for LPC formant tracking

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d37056bfd4832b81791a5285388719