### PR TITLE
feat: add spectrogram panel with formant extraction

### DIFF
--- a/rtva/dsp/lpc.py
+++ b/rtva/dsp/lpc.py
@@ -1,6 +1,102 @@
+from __future__ import annotations
+
+import math
+
 import numpy as np
+from numpy.typing import NDArray
+from scipy.linalg import LinAlgError, solve_toeplitz
 from scipy.signal import lfilter
 
+try:  # Praat bindings are optional in some environments
+    import parselmouth
+except Exception:  # pragma: no cover - parselmouth may be missing
+    parselmouth = None  # type: ignore
 
-def pre_emphasis(x: np.ndarray, coef=0.97):
-    return lfilter([1, -coef], [1], x)
+
+def pre_emphasis(x: NDArray[np.floating], coef: float = 0.97) -> NDArray[np.floating]:
+    """Apply a simple pre-emphasis filter."""
+
+    return lfilter([1.0, -coef], [1.0], x)
+
+
+def _roots_to_formants(
+    roots: NDArray[np.complexfloating], sr: int, fmax: int
+) -> tuple[float, float, float]:
+    """Convert LPC polynomial roots to up to three formant frequencies."""
+
+    if roots.size == 0:
+        return (0.0, 0.0, 0.0)
+
+    usable = roots[(np.abs(roots) > 1e-6) & (np.abs(roots) < 1.0 + 1e-6)]
+    usable = usable[np.imag(usable) >= 0]
+    if usable.size == 0:
+        return (0.0, 0.0, 0.0)
+
+    ang = np.arctan2(np.imag(usable), np.real(usable))
+    freqs = np.sort(ang * sr / (2.0 * np.pi))
+    freqs = freqs[(freqs > 50.0) & (freqs < float(fmax))]
+
+    out = np.zeros(3, dtype=float)
+    limit = min(3, freqs.size)
+    if limit:
+        out[:limit] = freqs[:limit]
+    return float(out[0]), float(out[1]), float(out[2])
+
+
+def lpc_formants(
+    frame: NDArray[np.floating], sr: int, order: int = 14, fmax: int = 5000
+) -> tuple[float, float, float]:
+    """Estimate up to the first three formants using LPC analysis."""
+
+    if frame.size == 0:
+        return (0.0, 0.0, 0.0)
+
+    x = np.asarray(frame, dtype=np.float64)
+    x = pre_emphasis(x, 0.97)
+    x *= np.hanning(x.size)
+
+    if not np.any(np.abs(x) > 0):
+        return (0.0, 0.0, 0.0)
+
+    autocorr = np.correlate(x, x, mode="full")[x.size - 1 :]
+    if autocorr.size <= order or autocorr[0] <= 0:
+        return (0.0, 0.0, 0.0)
+
+    r = autocorr[: order + 1]
+    try:
+        a_vec = solve_toeplitz((r[:-1], r[:-1]), r[1:])
+    except LinAlgError:
+        return (0.0, 0.0, 0.0)
+
+    a = np.concatenate(([1.0], -a_vec))
+    if not np.all(np.isfinite(a)):
+        return (0.0, 0.0, 0.0)
+
+    roots = np.roots(a)
+    return _roots_to_formants(roots, sr, fmax)
+
+
+def burg_formants_parselmouth(
+    frame: NDArray[np.floating], sr: int, fmax: int = 5500
+) -> tuple[float, float, float]:
+    """Estimate formants using Praat's Burg method via parselmouth."""
+
+    if parselmouth is None:
+        raise RuntimeError("parselmouth is not available")
+
+    snd = parselmouth.Sound(frame.astype(float), sampling_frequency=sr)
+    formant = snd.to_formant_burg(
+        time_step=0.0,
+        max_number_of_formants=5,
+        maximum_formant=fmax,
+        pre_emphasis_from=50.0,
+    )
+    t_mid = snd.xmin + 0.5 * snd.get_total_duration()
+    values: list[float] = []
+    for i in range(1, 4):
+        val = formant.get_value_at_time(i, t_mid)
+        if val is None or math.isnan(val):
+            values.append(0.0)
+        else:
+            values.append(float(val))
+    return values[0], values[1], values[2]

--- a/rtva/dsp/spectrum.py
+++ b/rtva/dsp/spectrum.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import numpy as np
+from numpy.typing import NDArray
+
+
+def stft_mag_db(
+    frames_2d: NDArray[np.floating], sr: int, n_fft: int, hop: int
+) -> tuple[NDArray[np.floating], NDArray[np.floating], NDArray[np.floating]]:
+    """Compute the STFT magnitude in dB for a stack of frames."""
+
+    if frames_2d.ndim != 2:
+        raise ValueError("frames_2d must be a 2-D array of shape (frames, samples)")
+
+    frames = np.asarray(frames_2d, dtype=np.float64)
+    if frames.shape[1] > n_fft:
+        n_fft = int(2 ** np.ceil(np.log2(frames.shape[1])))
+    spec = np.fft.rfft(frames, n=n_fft, axis=1)
+    mag = np.abs(spec)
+    eps = np.finfo(float).tiny
+    S_db = 20.0 * np.log10(np.maximum(mag, eps))
+
+    freqs = np.fft.rfftfreq(n_fft, d=1.0 / sr)
+    n_frames = frames.shape[0]
+    if n_frames == 0:
+        return (
+            np.empty((0, 0), dtype=float),
+            np.empty(0, dtype=float),
+            np.empty(0, dtype=float),
+        )
+    times = np.linspace(-(n_frames - 1) * hop / sr, 0.0, n_frames)
+
+    return S_db.T.astype(np.float32), freqs.astype(np.float32), times.astype(np.float32)
+
+
+def h1_h2_db(frame: NDArray[np.floating], sr: int, f0: float) -> float:
+    """Placeholder for future H1-H2 implementation (not yet in MVP)."""
+
+    raise NotImplementedError

--- a/rtva/tests/test_lpc.py
+++ b/rtva/tests/test_lpc.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import numpy as np
+from scipy.signal import lfilter
+
+from rtva.dsp.lpc import lpc_formants
+
+
+def _synth_vowel(
+    formants: list[float], bandwidths: list[float], sr: int, duration: float
+) -> np.ndarray:
+    rng = np.random.default_rng(0)
+    excitation = rng.standard_normal(int(sr * duration)).astype(np.float32)
+    signal = excitation
+    for f, bw in zip(formants, bandwidths):
+        r = np.exp(-np.pi * bw / sr)
+        theta = 2 * np.pi * f / sr
+        a = np.array([1.0, -2.0 * r * np.cos(theta), r**2])
+        b = np.array([1.0 - r])
+        signal = lfilter(b, a, signal)
+    return signal.astype(np.float32)
+
+
+def test_lpc_formants_tracks_targets():
+    sr = 16000
+    target_formants = [750.0, 1100.0, 2100.0]
+    bandwidths = [80.0, 100.0, 160.0]
+    tone = _synth_vowel(target_formants, bandwidths, sr=sr, duration=0.2)
+    start = int(0.05 * sr)
+    frame = tone[start : start + int(0.04 * sr)]
+    f1, f2, f3 = lpc_formants(frame, sr, order=14, fmax=4000)
+
+    results = [f1, f2, f3]
+    for est, target in zip(results, target_formants):
+        assert target * 0.85 < est < target * 1.15
+
+
+def test_lpc_formants_silence_returns_zero():
+    sr = 16000
+    silence = np.zeros(int(0.04 * sr), dtype=np.float32)
+    f1, f2, f3 = lpc_formants(silence, sr, order=12)
+    assert f1 == 0.0 and f2 == 0.0 and f3 == 0.0

--- a/rtva/tests/test_spectrum.py
+++ b/rtva/tests/test_spectrum.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import numpy as np
+
+from rtva.dsp.spectrum import stft_mag_db
+
+
+def test_stft_mag_db_shapes_and_axes():
+    sr = 16000
+    duration = 0.04
+    t = np.arange(0, duration, 1 / sr)
+    frame = np.sin(2 * np.pi * 440 * t).astype(np.float32)
+    frames = np.stack([frame, frame])
+    hop = int(0.01 * sr)
+
+    S_db, freqs, times = stft_mag_db(frames, sr, n_fft=1024, hop=hop)
+
+    assert S_db.shape[1] == frames.shape[0]
+    assert S_db.shape[0] == 513  # n_fft // 2 + 1
+    assert freqs.shape[0] == S_db.shape[0]
+    assert times.shape[0] == S_db.shape[1]
+    np.testing.assert_allclose(times[-1], 0.0)
+    np.testing.assert_allclose(times[0], -(frames.shape[0] - 1) * hop / sr)
+
+    peak_idx = np.argmax(S_db[:, -1])
+    peak_freq = freqs[peak_idx]
+    assert abs(peak_freq - 440) < 30


### PR DESCRIPTION
## Summary
- add LPC and Praat Burg formant extraction helpers
- implement STFT magnitude helper and a SpectroPanel with formant overlays
- update the main window to stream spectrogram/formant data and cover the DSP helpers with tests

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68d39375be68832ba2197ec6153c035e