### PR TITLE
Implement DSP pipeline, controls, and logging

### DIFF
--- a/rtva/config.py
+++ b/rtva/config.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, fields
+from pathlib import Path
+from typing import Any, Dict
+
+try:  # Prefer PyYAML if available
+    import yaml
+except Exception:  # pragma: no cover - YAML library may be missing
+    yaml = None  # type: ignore
+
+
+@dataclass
+class AnalyzerConfig:
+    sr: int = 48000
+    frame_ms: int = 32
+    hop_ms: int = 10
+    pitch_min: float = 120.0
+    pitch_max: float = 400.0
+    formant_method: str = "burg"
+    formant_max_hz: int = 5500
+    lpc_order: int = 16
+    log_rate_hz: int = 10
+
+
+def _coerce(field_name: str, value: Any) -> Any:
+    for f in fields(AnalyzerConfig):
+        if f.name == field_name:
+            typ = f.type
+            if typ is int:
+                return int(value)
+            if typ is float:
+                return float(value)
+            if typ is str:
+                return str(value)
+            return value
+    return value
+
+
+def save_preset(path: str | Path, cfg: AnalyzerConfig) -> None:
+    data = asdict(cfg)
+    file_path = Path(path)
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+
+    if yaml is not None:
+        with file_path.open("w", encoding="utf-8") as fh:
+            yaml.safe_dump(data, fh, allow_unicode=True, sort_keys=False)
+        return
+
+    with file_path.open("w", encoding="utf-8") as fh:
+        for key, value in data.items():
+            if isinstance(value, str):
+                fh.write(f"{key}: '{value}'\n")
+            else:
+                fh.write(f"{key}: {value}\n")
+
+
+def load_preset(path: str | Path) -> AnalyzerConfig:
+    file_path = Path(path)
+    if not file_path.exists():
+        raise FileNotFoundError(file_path)
+
+    if yaml is not None:
+        with file_path.open("r", encoding="utf-8") as fh:
+            data = yaml.safe_load(fh) or {}
+    else:
+        data: Dict[str, Any] = {}
+        with file_path.open("r", encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line or line.startswith("#"):
+                    continue
+                key, _, raw = line.partition(":")
+                if not _:
+                    continue
+                key = key.strip()
+                raw = raw.strip()
+                if raw.startswith("'") and raw.endswith("'"):
+                    value: Any = raw[1:-1]
+                else:
+                    try:
+                        value = int(raw)
+                    except ValueError:
+                        try:
+                            value = float(raw)
+                        except ValueError:
+                            if raw.lower() in {"true", "false"}:
+                                value = raw.lower() == "true"
+                            else:
+                                value = raw
+                data[key] = value
+
+    coerced = {name: _coerce(name, value) for name, value in data.items()}
+    return AnalyzerConfig(**coerced)

--- a/rtva/dsp/cepstrum.py
+++ b/rtva/dsp/cepstrum.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import numpy as np
+from numpy.typing import NDArray
+
+
+def cpp_db(frame: NDArray[np.floating], sr: int, frame_ms: int = 46) -> float:
+    """Compute the cepstral peak prominence in dB."""
+
+    if frame_ms <= 0:
+        raise ValueError("frame_ms must be positive")
+
+    n_win = int(round(sr * frame_ms / 1000))
+    if n_win <= 0:
+        return float(np.nan)
+
+    x = np.asarray(frame, dtype=np.float64)
+    if x.size == 0 or not np.any(np.isfinite(x)):
+        return float(np.nan)
+
+    if x.size < n_win:
+        pad = n_win - x.size
+        x = np.pad(x, (0, pad))
+    else:
+        x = x[:n_win]
+
+    x = x * np.hanning(n_win)
+    if not np.any(np.abs(x) > 0):
+        return float(np.nan)
+
+    n_fft = 1 << int(np.ceil(np.log2(n_win * 2)))
+    spec = np.fft.rfft(x, n=n_fft)
+    mag = np.abs(spec) + 1e-12
+    log_mag = 20.0 * np.log10(mag)
+    cep = np.fft.irfft(log_mag, n=n_fft)
+
+    quef = np.arange(n_fft) / float(sr)
+    q_min = 1.0 / 500.0  # ≈ 500 Hz
+    q_max = 1.0 / 60.0  # ≈ 60 Hz
+    mask = (quef >= q_min) & (quef <= q_max)
+    if not np.any(mask):
+        return float(np.nan)
+
+    q_sel = quef[mask]
+    cep_sel = cep[mask]
+    peak_idx = int(np.argmax(cep_sel))
+    peak_val = float(cep_sel[peak_idx])
+    q_peak = float(q_sel[peak_idx])
+
+    if q_sel.size < 2:
+        return float(np.nan)
+
+    baseline_interp = float(np.interp(q_peak, [q_sel[0], q_sel[-1]], [cep_sel[0], cep_sel[-1]]))
+    return float(max(peak_val - baseline_interp, 0.0))

--- a/rtva/dsp/spectrum.py
+++ b/rtva/dsp/spectrum.py
@@ -5,35 +5,85 @@ from numpy.typing import NDArray
 
 
 def stft_mag_db(
-    frames_2d: NDArray[np.floating], sr: int, n_fft: int, hop: int
+    x: NDArray[np.floating], sr: int, n_fft: int, hop: int, win: NDArray[np.floating]
 ) -> tuple[NDArray[np.floating], NDArray[np.floating], NDArray[np.floating]]:
-    """Compute the STFT magnitude in dB for a stack of frames."""
+    """Compute the STFT magnitude in dB for a 1-D signal."""
 
-    if frames_2d.ndim != 2:
-        raise ValueError("frames_2d must be a 2-D array of shape (frames, samples)")
+    sig = np.asarray(x, dtype=np.float32).reshape(-1)
+    if sig.size == 0:
+        return (
+            np.empty((0, 0), dtype=np.float32),
+            np.empty(0, dtype=np.float32),
+            np.empty(0, dtype=np.float32),
+        )
 
-    frames = np.asarray(frames_2d, dtype=np.float64)
-    if frames.shape[1] > n_fft:
-        n_fft = int(2 ** np.ceil(np.log2(frames.shape[1])))
+    window = np.asarray(win, dtype=np.float32).reshape(-1)
+    if window.size == 0:
+        raise ValueError("win must be a non-empty 1-D array")
+
+    frame_len = window.size
+    if hop <= 0:
+        raise ValueError("hop must be positive")
+
+    if sig.size < frame_len:
+        pad = frame_len - sig.size
+        sig = np.pad(sig, (pad, 0))
+
+    if sig.size > frame_len:
+        remainder = (sig.size - frame_len) % hop
+        if remainder:
+            sig = sig[remainder:]
+
+    if n_fft < frame_len:
+        n_fft = 1 << int(np.ceil(np.log2(frame_len)))
+
+    frames = np.lib.stride_tricks.sliding_window_view(sig, frame_len)[::hop]
+    if frames.size == 0:
+        frames = sig[-frame_len:].reshape(1, -1)
+
+    frames = frames.astype(np.float32) * window
     spec = np.fft.rfft(frames, n=n_fft, axis=1)
     mag = np.abs(spec)
-    eps = np.finfo(float).tiny
-    S_db = 20.0 * np.log10(np.maximum(mag, eps))
+    S_db = 20.0 * np.log10(np.maximum(mag, 1e-8))
 
-    freqs = np.fft.rfftfreq(n_fft, d=1.0 / sr)
+    freqs = np.fft.rfftfreq(n_fft, d=1.0 / sr).astype(np.float32)
     n_frames = frames.shape[0]
-    if n_frames == 0:
-        return (
-            np.empty((0, 0), dtype=float),
-            np.empty(0, dtype=float),
-            np.empty(0, dtype=float),
-        )
-    times = np.linspace(-(n_frames - 1) * hop / sr, 0.0, n_frames)
+    times = np.linspace(-(n_frames - 1) * hop / sr, 0.0, n_frames).astype(np.float32)
 
-    return S_db.T.astype(np.float32), freqs.astype(np.float32), times.astype(np.float32)
+    return S_db.T.astype(np.float32, copy=False), freqs, times
 
 
 def h1_h2_db(frame: NDArray[np.floating], sr: int, f0: float) -> float:
-    """Placeholder for future H1-H2 implementation (not yet in MVP)."""
+    """Estimate the H1-H2 spectral level difference in dB."""
 
-    raise NotImplementedError
+    if f0 <= 0 or not np.isfinite(f0):
+        return float(np.nan)
+
+    x = np.asarray(frame, dtype=np.float64)
+    if x.size == 0 or not np.any(np.isfinite(x)):
+        return float(np.nan)
+
+    x = x * np.hanning(x.size)
+    if not np.any(np.abs(x) > 0):
+        return float(np.nan)
+
+    n_fft = max(2048, 1 << int(np.ceil(np.log2(x.size * 2))))
+    spec = np.fft.rfft(x, n=n_fft)
+    mag = np.abs(spec)
+    freqs = np.fft.rfftfreq(n_fft, d=1.0 / sr)
+
+    def _peak(target: float) -> float | None:
+        if target >= freqs[-1]:
+            return None
+        bw = max(20.0, target * 0.25)
+        mask = np.logical_and(freqs >= target - bw, freqs <= target + bw)
+        if not np.any(mask):
+            return None
+        return float(np.max(mag[mask]))
+
+    h1 = _peak(f0)
+    h2 = _peak(2.0 * f0)
+    if h1 is None or h2 is None or h1 <= 0 or h2 <= 0:
+        return float(np.nan)
+
+    return 20.0 * np.log10((h1 + 1e-12) / (h2 + 1e-12))

--- a/rtva/dsp/vad.py
+++ b/rtva/dsp/vad.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import numpy as np
+from numpy.typing import NDArray
+
+
+def rms_db(frame: NDArray[np.floating]) -> float:
+    """Return RMS in decibels."""
+
+    x = np.asarray(frame, dtype=np.float64)
+    if x.size == 0:
+        return float("-inf")
+    rms = np.sqrt(np.mean(np.square(x)))
+    return float(20.0 * np.log10(rms + 1e-12))
+
+
+def simple_vad(frame: NDArray[np.floating], sr: int, thr_db: float = -45.0) -> bool:
+    """Simple energy-based VAD with optional zero-crossing check."""
+
+    level = rms_db(frame)
+    if not np.isfinite(level) or level < thr_db:
+        return False
+
+    x = np.asarray(frame, dtype=np.float64)
+    if x.size < 2:
+        return False
+
+    signs = np.signbit(x)
+    zcr = np.count_nonzero(signs[1:] != signs[:-1]) / (x.size - 1)
+    max_zcr = 0.45
+    if zcr > max_zcr:
+        return False
+
+    return True

--- a/rtva/logging/recorder.py
+++ b/rtva/logging/recorder.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import time
+from datetime import datetime
+from pathlib import Path
+from queue import Empty, Queue
+from threading import Event, Thread
+from typing import Any, Dict, Iterable, Optional
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+
+class ParquetRecorder:
+    def __init__(self, out_dir: Path, rate_hz: int = 10) -> None:
+        self.out_dir = Path(out_dir)
+        self.rate_hz = max(1, int(rate_hz))
+        self._queue: "Queue[Dict[str, Any]]" = Queue()
+        self._thread: Optional[Thread] = None
+        self._stop = Event()
+        self._writer: Optional[pq.ParquetWriter] = None
+        self.session_dir: Optional[Path] = None
+        self.file_path: Optional[Path] = None
+        self._schema = pa.schema(
+            [
+                ("timestamp_ns", pa.int64()),
+                ("f0_hz", pa.float32()),
+                ("f1_hz", pa.float32()),
+                ("f2_hz", pa.float32()),
+                ("f3_hz", pa.float32()),
+                ("h1_h2_db", pa.float32()),
+                ("cpp_db", pa.float32()),
+                ("rms_db", pa.float32()),
+                ("voiced", pa.bool_()),
+                ("sr", pa.int32()),
+                ("frame_ms", pa.int32()),
+                ("hop_ms", pa.int32()),
+                ("pitch_min", pa.float32()),
+                ("pitch_max", pa.float32()),
+                ("formant_max_hz", pa.int32()),
+                ("lpc_order", pa.int32()),
+                ("formant_method", pa.string()),
+            ]
+        )
+
+    def start(self) -> None:
+        if self._thread and self._thread.is_alive():
+            return
+
+        date_str = datetime.now().strftime("%Y%m%d_%H%M%S")
+        self.session_dir = self.out_dir / date_str
+        self.session_dir.mkdir(parents=True, exist_ok=True)
+        self.file_path = self.session_dir / "log.parquet"
+        self._stop.clear()
+        self._thread = Thread(target=self._worker, name="ParquetRecorder", daemon=True)
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._stop.set()
+        if self._thread:
+            self._thread.join()
+            self._thread = None
+        if self._writer is not None:
+            self._writer.close()
+            self._writer = None
+
+    def push(self, row: Dict[str, Any]) -> None:
+        if not self._thread:
+            return
+        self._queue.put(row)
+
+    def _ensure_writer(self) -> None:
+        if self._writer is None:
+            if self.file_path is None:
+                raise RuntimeError("Recorder has not been started")
+            self._writer = pq.ParquetWriter(self.file_path, self._schema)
+
+    def _normalize_rows(self, rows: Iterable[Dict[str, Any]]) -> pa.Table:
+        normalized = []
+        for row in rows:
+            item: Dict[str, Any] = {}
+            for field in self._schema.names:
+                value = row.get(field)
+                if value is None:
+                    item[field] = None
+                elif field == "voiced":
+                    item[field] = bool(value)
+                elif field in {"timestamp_ns"}:
+                    item[field] = int(value)
+                elif self._schema.field(field).type == pa.int32():
+                    item[field] = int(value)
+                elif self._schema.field(field).type == pa.float32():
+                    item[field] = float(value)
+                else:
+                    item[field] = str(value)
+            normalized.append(item)
+        return pa.Table.from_pylist(normalized, schema=self._schema)
+
+    def _worker(self) -> None:
+        last_flush = time.monotonic()
+        pending: list[Dict[str, Any]] = []
+        interval = 1.0 / float(max(1, self.rate_hz))
+        while not self._stop.is_set() or not self._queue.empty():
+            try:
+                row = self._queue.get(timeout=0.1)
+                pending.append(row)
+            except Empty:
+                pass
+
+            now = time.monotonic()
+            if pending and (now - last_flush >= interval or self._stop.is_set()):
+                self._ensure_writer()
+                table = self._normalize_rows(pending)
+                self._writer.write_table(table)
+                pending.clear()
+                last_flush = now
+                interval = 1.0 / float(max(1, self.rate_hz))
+
+        if pending:
+            self._ensure_writer()
+            table = self._normalize_rows(pending)
+            self._writer.write_table(table)
+            pending.clear()

--- a/rtva/tests/conftest.py
+++ b/rtva/tests/conftest.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/rtva/tests/test_h1h2_cpp.py
+++ b/rtva/tests/test_h1h2_cpp.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import numpy as np
+
+from rtva.dsp.cepstrum import cpp_db
+from rtva.dsp.spectrum import h1_h2_db
+
+
+def test_h1h2_positive_for_strong_fundamental() -> None:
+    sr = 16000
+    t = np.arange(0, int(0.05 * sr)) / sr
+    fundamental = np.sin(2 * np.pi * 200 * t)
+    second = 0.3 * np.sin(2 * np.pi * 400 * t)
+    frame = (fundamental + second).astype(np.float32)
+
+    value = h1_h2_db(frame, sr, f0=200.0)
+    assert np.isfinite(value)
+    assert value > 0.0
+
+
+def test_cpp_decreases_with_noise() -> None:
+    sr = 16000
+    t = np.arange(0, int(0.06 * sr)) / sr
+    clean = np.sin(2 * np.pi * 180 * t).astype(np.float32)
+    rng = np.random.default_rng(42)
+    noisy = (clean + 2.0 * rng.standard_normal(clean.size)).astype(np.float32)
+
+    cpp_clean = cpp_db(clean, sr)
+    cpp_noisy = cpp_db(noisy, sr)
+
+    assert np.isfinite(cpp_clean)
+    assert cpp_clean > cpp_noisy

--- a/rtva/tests/test_lpc_impl.py
+++ b/rtva/tests/test_lpc_impl.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from scipy.signal import lfilter
+
+from rtva.dsp.lpc import burg_formants_parselmouth, lpc_formants
+
+try:
+    import parselmouth  # noqa: F401
+
+    PARSELMOUTH_AVAILABLE = True
+except Exception:  # pragma: no cover - optional dependency
+    PARSELMOUTH_AVAILABLE = False
+
+
+def _synth_vowel(formants: tuple[float, float, float], sr: int, duration: float) -> np.ndarray:
+    rng = np.random.default_rng(1234)
+    excitation = rng.standard_normal(int(sr * duration)).astype(np.float32)
+    signal = excitation
+    bandwidths = (80.0, 90.0, 160.0)
+    for f, bw in zip(formants, bandwidths):
+        r = np.exp(-np.pi * bw / sr)
+        theta = 2 * np.pi * f / sr
+        a = np.array([1.0, -2.0 * r * np.cos(theta), r**2], dtype=np.float64)
+        b = np.array([1.0 - r], dtype=np.float64)
+        signal = lfilter(b, a, signal)
+    return signal.astype(np.float32)
+
+
+@pytest.mark.parametrize("method", ["lpc", "burg"])
+def test_formant_estimators_reasonable(method: str) -> None:
+    sr = 16000
+    targets = (700.0, 1200.0, 2500.0)
+    tone = _synth_vowel(targets, sr=sr, duration=0.2)
+    start = int(0.08 * sr)
+    frame = tone[start : start + int(0.05 * sr)]
+
+    if method == "burg":
+        if not PARSELMOUTH_AVAILABLE:
+            pytest.xfail("parselmouth not available")
+        f1, f2, f3 = burg_formants_parselmouth(frame, sr, fmax=4000)
+        if (f1, f2, f3) == (0.0, 0.0, 0.0):
+            pytest.xfail("parselmouth backend unavailable")
+    else:
+        f1, f2, f3 = lpc_formants(frame, sr, order=16, fmax=4000)
+
+    estimates = (f1, f2, f3)
+    for est, target in zip(estimates[:2], targets[:2]):
+        assert target * 0.85 < est < target * 1.15
+
+
+def test_lpc_returns_zero_for_silence() -> None:
+    sr = 16000
+    silence = np.zeros(int(0.04 * sr), dtype=np.float32)
+    f1, f2, f3 = lpc_formants(silence, sr)
+    assert (f1, f2, f3) == (0.0, 0.0, 0.0)

--- a/rtva/tests/test_spectrum.py
+++ b/rtva/tests/test_spectrum.py
@@ -8,19 +8,20 @@ from rtva.dsp.spectrum import stft_mag_db
 def test_stft_mag_db_shapes_and_axes():
     sr = 16000
     duration = 0.04
-    t = np.arange(0, duration, 1 / sr)
-    frame = np.sin(2 * np.pi * 440 * t).astype(np.float32)
-    frames = np.stack([frame, frame])
     hop = int(0.01 * sr)
+    frame_len = int(0.032 * sr)
+    win = np.hanning(frame_len)
+    t = np.arange(0, duration, 1 / sr)
+    signal = np.sin(2 * np.pi * 440 * t).astype(np.float32)
 
-    S_db, freqs, times = stft_mag_db(frames, sr, n_fft=1024, hop=hop)
+    S_db, freqs, times = stft_mag_db(signal, sr, n_fft=1024, hop=hop, win=win)
 
-    assert S_db.shape[1] == frames.shape[0]
     assert S_db.shape[0] == 513  # n_fft // 2 + 1
     assert freqs.shape[0] == S_db.shape[0]
     assert times.shape[0] == S_db.shape[1]
     np.testing.assert_allclose(times[-1], 0.0)
-    np.testing.assert_allclose(times[0], -(frames.shape[0] - 1) * hop / sr)
+    expected_frames = 1 + (len(signal) - frame_len) // hop
+    np.testing.assert_allclose(times.shape[0], expected_frames)
 
     peak_idx = np.argmax(S_db[:, -1])
     peak_freq = freqs[peak_idx]

--- a/rtva/tests/test_vad_rms.py
+++ b/rtva/tests/test_vad_rms.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import numpy as np
+
+from rtva.dsp.vad import rms_db, simple_vad
+
+
+def test_rms_db_matches_expected_value() -> None:
+    frame = np.full(480, 0.5, dtype=np.float32)
+    level = rms_db(frame)
+    assert np.isfinite(level)
+    assert abs(level + 6.0206) < 0.5  # 0.5 amplitude ≈ -6 dB
+
+
+def test_simple_vad_detects_tone() -> None:
+    sr = 48000
+    t = np.arange(0, int(0.03 * sr)) / sr
+    frame = 0.1 * np.sin(2 * np.pi * 200 * t).astype(np.float32)
+    assert simple_vad(frame, sr, thr_db=-40.0)
+
+
+def test_simple_vad_rejects_quiet_noise() -> None:
+    sr = 48000
+    rng = np.random.default_rng(123)
+    noise = (1e-3 * rng.standard_normal(int(0.03 * sr))).astype(np.float32)
+    assert not simple_vad(noise, sr, thr_db=-40.0)

--- a/rtva/ui/controls.py
+++ b/rtva/ui/controls.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from PyQt6.QtCore import pyqtSignal
+from PyQt6.QtWidgets import (
+    QComboBox,
+    QDoubleSpinBox,
+    QFileDialog,
+    QFormLayout,
+    QGroupBox,
+    QHBoxLayout,
+    QPushButton,
+    QSpinBox,
+    QVBoxLayout,
+    QWidget,
+)
+
+from rtva.config import AnalyzerConfig, load_preset, save_preset
+
+
+class ControlsPanel(QWidget):
+    config_changed = pyqtSignal(AnalyzerConfig)
+
+    def __init__(self, cfg: AnalyzerConfig, parselmouth_available: bool = True) -> None:
+        super().__init__()
+        self._cfg = cfg
+        self._parselmouth_available = parselmouth_available
+        self._updating = False
+
+        layout = QVBoxLayout()
+        self.setLayout(layout)
+
+        form_box = QGroupBox("Analyzer")
+        form_layout = QFormLayout()
+        form_box.setLayout(form_layout)
+
+        self.sr_spin = QSpinBox()
+        self.sr_spin.setRange(8000, 192000)
+        self.sr_spin.setSingleStep(1000)
+        form_layout.addRow("Sample rate", self.sr_spin)
+
+        self.frame_spin = QSpinBox()
+        self.frame_spin.setRange(8, 128)
+        self.frame_spin.setSingleStep(2)
+        form_layout.addRow("Frame (ms)", self.frame_spin)
+
+        self.hop_spin = QSpinBox()
+        self.hop_spin.setRange(1, 100)
+        form_layout.addRow("Hop (ms)", self.hop_spin)
+
+        self.pitch_min_spin = QDoubleSpinBox()
+        self.pitch_min_spin.setRange(20.0, 1000.0)
+        self.pitch_min_spin.setDecimals(1)
+        self.pitch_min_spin.setSingleStep(5.0)
+        form_layout.addRow("Pitch min", self.pitch_min_spin)
+
+        self.pitch_max_spin = QDoubleSpinBox()
+        self.pitch_max_spin.setRange(50.0, 2000.0)
+        self.pitch_max_spin.setDecimals(1)
+        self.pitch_max_spin.setSingleStep(5.0)
+        form_layout.addRow("Pitch max", self.pitch_max_spin)
+
+        self.formant_combo = QComboBox()
+        self.formant_combo.addItems(["burg", "lpc"])
+        if not parselmouth_available:
+            index = self.formant_combo.findText("burg")
+            if index >= 0:
+                self.formant_combo.removeItem(index)
+        form_layout.addRow("Formant method", self.formant_combo)
+
+        self.formant_max_spin = QSpinBox()
+        self.formant_max_spin.setRange(1000, 10000)
+        self.formant_max_spin.setSingleStep(100)
+        form_layout.addRow("Formant max (Hz)", self.formant_max_spin)
+
+        self.lpc_order_spin = QSpinBox()
+        self.lpc_order_spin.setRange(8, 32)
+        form_layout.addRow("LPC order", self.lpc_order_spin)
+
+        self.log_rate_spin = QSpinBox()
+        self.log_rate_spin.setRange(1, 60)
+        form_layout.addRow("Log rate (Hz)", self.log_rate_spin)
+
+        layout.addWidget(form_box)
+
+        buttons_layout = QHBoxLayout()
+        self.save_btn = QPushButton("Save preset")
+        self.save_btn.clicked.connect(self._save_preset)
+        buttons_layout.addWidget(self.save_btn)
+
+        self.load_btn = QPushButton("Load preset")
+        self.load_btn.clicked.connect(self._load_preset)
+        buttons_layout.addWidget(self.load_btn)
+        layout.addLayout(buttons_layout)
+
+        layout.addStretch(1)
+
+        self._connect_signals()
+        self.set_config(cfg)
+
+    def _connect_signals(self) -> None:
+        widgets = [
+            self.sr_spin,
+            self.frame_spin,
+            self.hop_spin,
+            self.pitch_min_spin,
+            self.pitch_max_spin,
+            self.formant_combo,
+            self.formant_max_spin,
+            self.lpc_order_spin,
+            self.log_rate_spin,
+        ]
+        for widget in widgets:
+            if isinstance(widget, QComboBox):
+                widget.currentTextChanged.connect(self._emit_config)
+            elif isinstance(widget, QDoubleSpinBox):
+                widget.valueChanged.connect(self._emit_config)
+            else:
+                widget.valueChanged.connect(self._emit_config)
+
+    def set_config(self, cfg: AnalyzerConfig) -> None:
+        self._updating = True
+        self._cfg = cfg
+        try:
+            self.sr_spin.setValue(cfg.sr)
+            self.frame_spin.setValue(cfg.frame_ms)
+            self.hop_spin.setValue(cfg.hop_ms)
+            self.pitch_min_spin.setValue(cfg.pitch_min)
+            self.pitch_max_spin.setValue(cfg.pitch_max)
+            idx = self.formant_combo.findText(cfg.formant_method)
+            if idx >= 0:
+                self.formant_combo.setCurrentIndex(idx)
+            else:
+                self.formant_combo.setCurrentIndex(0)
+            self.formant_max_spin.setValue(cfg.formant_max_hz)
+            self.lpc_order_spin.setValue(cfg.lpc_order)
+            self.log_rate_spin.setValue(cfg.log_rate_hz)
+        finally:
+            self._updating = False
+
+    def _emit_config(self) -> None:
+        if self._updating:
+            return
+        cfg = AnalyzerConfig(
+            sr=int(self.sr_spin.value()),
+            frame_ms=int(self.frame_spin.value()),
+            hop_ms=int(self.hop_spin.value()),
+            pitch_min=float(self.pitch_min_spin.value()),
+            pitch_max=float(self.pitch_max_spin.value()),
+            formant_method=self.formant_combo.currentText(),
+            formant_max_hz=int(self.formant_max_spin.value()),
+            lpc_order=int(self.lpc_order_spin.value()),
+            log_rate_hz=int(self.log_rate_spin.value()),
+        )
+        if not self._parselmouth_available and cfg.formant_method == "burg":
+            cfg.formant_method = "lpc"
+            idx = self.formant_combo.findText("lpc")
+            if idx >= 0:
+                self.formant_combo.setCurrentIndex(idx)
+        self._cfg = cfg
+        self.config_changed.emit(cfg)
+
+    def _save_preset(self) -> None:
+        directory = self._default_dir()
+        path, _ = QFileDialog.getSaveFileName(
+            self,
+            "Save preset",
+            str(directory / "preset.yaml"),
+            "YAML Files (*.yaml)",
+        )
+        if path:
+            save_preset(path, self._cfg)
+
+    def _load_preset(self) -> None:
+        directory = self._default_dir()
+        path, _ = QFileDialog.getOpenFileName(
+            self,
+            "Load preset",
+            str(directory),
+            "YAML Files (*.yaml)",
+        )
+        if not path:
+            return
+        cfg = load_preset(path)
+        self.set_config(cfg)
+        self.config_changed.emit(cfg)
+
+    def _default_dir(self) -> Path:
+        base = Path.home() / "rtva_presets"
+        base.mkdir(parents=True, exist_ok=True)
+        return base

--- a/rtva/ui/main_window.py
+++ b/rtva/ui/main_window.py
@@ -1,93 +1,258 @@
 from __future__ import annotations
 
+import time
 from collections import deque
+from dataclasses import replace
+from pathlib import Path
+from typing import Deque, Optional
 
 import numpy as np
 from PyQt6.QtCore import QTimer
-from PyQt6.QtWidgets import QMainWindow, QVBoxLayout, QWidget
+from PyQt6.QtWidgets import QHBoxLayout, QMainWindow, QVBoxLayout, QWidget
 
 from rtva.audio import AudioStream, hann
+from rtva.config import AnalyzerConfig, save_preset
+from rtva.dsp.cepstrum import cpp_db
 from rtva.dsp.lpc import burg_formants_parselmouth, lpc_formants
 from rtva.dsp.pitch import yin_f0
-from rtva.dsp.spectrum import stft_mag_db
+from rtva.dsp.spectrum import h1_h2_db, stft_mag_db
+from rtva.dsp.vad import rms_db, simple_vad
+from rtva.logging.recorder import ParquetRecorder
+from rtva.ui.controls import ControlsPanel
 from rtva.ui.panels import CPPPanel, HarmonicsPanel, PitchPanel, SpectroPanel
+
+try:  # Praat bindings availability
+    import parselmouth  # noqa: F401
+
+    PARSELMOUTH_AVAILABLE = True
+except Exception:  # pragma: no cover - optional dependency
+    PARSELMOUTH_AVAILABLE = False
+
+
+SESSIONS_DIR = Path("sessions")
 
 
 class MainWindow(QMainWindow):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.setWindowTitle("RTVA — Real-Time Voice Analyzer")
 
-        # === GUI ===
+        self.cfg = AnalyzerConfig()
+        self._cpp_rate_hz = 2.0
+        self._cpp_stride = 1
+        self._cpp_counter = 0
+        self._last_cpp = float("nan")
+        self._warn_burg_once = False
+
+        self._parselmouth_available = PARSELMOUTH_AVAILABLE
+
         central = QWidget(self)
-        lay = QVBoxLayout(central)
-        self.pitch = PitchPanel(timespan_sec=10, sr_hop=100)
+        root_layout = QHBoxLayout(central)
+        self.controls = ControlsPanel(self.cfg, parselmouth_available=self._parselmouth_available)
+        root_layout.addWidget(self.controls, stretch=0)
+
+        panels = QWidget(self)
+        panels_layout = QVBoxLayout()
+        panels.setLayout(panels_layout)
+
+        self.pitch = PitchPanel(timespan_sec=10, sr_hop=int(round(1000 / self.cfg.hop_ms)))
         self.spectro = SpectroPanel()
-        self.harm = HarmonicsPanel()
-        self.cpp = CPPPanel()
-        lay.addWidget(self.pitch)
-        lay.addWidget(self.spectro)
-        lay.addWidget(self.harm)
-        lay.addWidget(self.cpp)
+        self.harm = HarmonicsPanel(timespan_sec=10, sr_hop=int(round(1000 / self.cfg.hop_ms)))
+        self.cpp = CPPPanel(timespan_sec=30, sr_hop=int(max(1, round(self._cpp_rate_hz))))
+
+        panels_layout.addWidget(self.pitch)
+        panels_layout.addWidget(self.spectro)
+        panels_layout.addWidget(self.harm)
+        panels_layout.addWidget(self.cpp)
+        root_layout.addWidget(panels, stretch=1)
         self.setCentralWidget(central)
 
-        # === Audio / DSP ===
-        self.sr = 44100
-        self.hop_ms = 10  # 10msごと更新 ≒ 100 Hz
-        self.win_ms = 32
-        self.blocksize = int(self.sr * self.hop_ms / 1000)
-        self.win = int(self.sr * self.win_ms / 1000)
-        self.win_buf = np.zeros(self.win, dtype=np.float32)
-        self.win_hann = hann(self.win)
+        self.controls.config_changed.connect(self._apply_config)
 
-        self.formant_method = "burg"
-        self.formant_max_hz = 5500
-        self.lpc_order = 16
-        self.spec_history_frames = int(5 * 100)  # 5秒分の表示
-        self.frames_buffer: deque[np.ndarray] = deque(maxlen=self.spec_history_frames)
-        self.formant_history = [deque(maxlen=self.spec_history_frames) for _ in range(3)]
-        self.n_fft = 2048
-
-        self.stream = AudioStream(sr=self.sr, blocksize=self.blocksize)
-        self.stream.start()
-
-        # ~100Hz でループ
+        self.stream: Optional[AudioStream] = None
         self.timer = QTimer(self)
         self.timer.timeout.connect(self._tick)
-        self.timer.start(self.hop_ms)
 
-    def closeEvent(self, e):
-        try:
-            self.stream.stop()
-        except Exception:
-            pass
-        return super().closeEvent(e)
+        self.recorder = ParquetRecorder(SESSIONS_DIR, rate_hz=self.cfg.log_rate_hz)
+        self.recorder.start()
 
-    def _tick(self):
-        # 新ブロックを取り出し、スライディングウィンドウ更新
+        self._spectrogram_window_sec = 5.0
+        self._n_fft = 4096
+
+        self._audio_buffer = np.zeros(1, dtype=np.float32)
+        self._analysis_window = np.ones(1, dtype=np.float32)
+        self._formant_history: tuple[Deque[float], Deque[float], Deque[float]] = (
+            deque(),
+            deque(),
+            deque(),
+        )
+
+        self._apply_config(self.cfg)
+        self.timer.start(self.cfg.hop_ms)
+        self._save_session_settings()
+
+    def closeEvent(self, event):  # type: ignore[override]
+        if self.timer.isActive():
+            self.timer.stop()
+        if self.stream is not None:
+            try:
+                self.stream.stop()
+            except Exception:
+                pass
+        self.recorder.stop()
+        return super().closeEvent(event)
+
+    def _apply_config(self, cfg: AnalyzerConfig) -> None:
+        if cfg.formant_method == "burg" and not self._parselmouth_available:
+            cfg = replace(cfg, formant_method="lpc")
+            self.controls.set_config(cfg)
+
+        self.cfg = cfg
+        self._cpp_stride = max(1, int(round((1000.0 / cfg.hop_ms) / self._cpp_rate_hz)))
+        self._cpp_counter = 0
+
+        hop_samples = max(1, int(round(cfg.sr * cfg.hop_ms / 1000)))
+        frame_samples = max(hop_samples, int(round(cfg.sr * cfg.frame_ms / 1000)))
+        self._n_fft = max(2048, 1 << int(np.ceil(np.log2(frame_samples))))
+
+        if self.stream is not None:
+            try:
+                self.stream.stop()
+            except Exception:
+                pass
+        self.stream = AudioStream(sr=cfg.sr, blocksize=hop_samples)
+        self.stream.start()
+
+        buffer_frames = max(1, int(self._spectrogram_window_sec * 1000 / cfg.hop_ms))
+        buffer_len = frame_samples + max(0, buffer_frames - 1) * hop_samples
+        self._audio_buffer = np.zeros(buffer_len, dtype=np.float32)
+        self._analysis_window = hann(frame_samples).astype(np.float32)
+        self._formant_history = (
+            deque([np.nan] * buffer_frames, maxlen=buffer_frames),
+            deque([np.nan] * buffer_frames, maxlen=buffer_frames),
+            deque([np.nan] * buffer_frames, maxlen=buffer_frames),
+        )
+
+        rate_hz = 1000.0 / cfg.hop_ms
+        self.pitch.set_rate(rate_hz)
+        self.harm.set_rate(rate_hz)
+        self.cpp.set_rate(self._cpp_rate_hz)
+
+        self.timer.setInterval(cfg.hop_ms)
+        self.recorder.rate_hz = cfg.log_rate_hz
+        self._save_session_settings()
+
+    def _append_audio(self, hop: np.ndarray) -> None:
+        hop = hop.astype(np.float32, copy=False)
+        n = hop.size
+        if n >= self._audio_buffer.size:
+            self._audio_buffer[:] = hop[-self._audio_buffer.size :]
+        else:
+            self._audio_buffer = np.roll(self._audio_buffer, -n)
+            self._audio_buffer[-n:] = hop
+
+    def _current_frame(self) -> np.ndarray:
+        frame_len = self._analysis_window.size
+        return self._audio_buffer[-frame_len:]
+
+    def _tick(self) -> None:
+        if self.stream is None:
+            return
+
         try:
             hop = self.stream.read()
         except Exception:
             return
-        self.win_buf = np.roll(self.win_buf, -len(hop))
-        self.win_buf[-len(hop) :] = hop
-        frame = (self.win_buf * self.win_hann).astype(np.float32)
 
-        # F0推定（YIN）
-        f0 = yin_f0(frame, self.sr, fmin=75, fmax=350)  # 後でUIから変更可
+        self._append_audio(hop)
+        frame = (self._current_frame() * self._analysis_window).astype(np.float32)
+
+        rms = rms_db(frame)
+        voiced = simple_vad(frame, self.cfg.sr)
+
+        f0 = yin_f0(frame, self.cfg.sr, fmin=self.cfg.pitch_min, fmax=self.cfg.pitch_max)
+        if not voiced:
+            f0 = 0.0
         self.pitch.update_pitch(f0)
+        self.pitch.update_stability(self._cents_std_recent())
 
-        # 簡易：直近0.5秒の±centゆらぎ
-        cents_std = self._cents_std_recent()
-        self.pitch.update_stability(cents_std)
+        f1 = f2 = f3 = np.nan
+        if voiced:
+            if self.cfg.formant_method == "burg":
+                f1, f2, f3 = burg_formants_parselmouth(
+                    frame, self.cfg.sr, fmax=self.cfg.formant_max_hz
+                )
+                if (f1, f2, f3) == (0.0, 0.0, 0.0):
+                    if not self._warn_burg_once:
+                        print("[WARN] parselmouth unavailable, falling back to LPC formants")
+                        self._warn_burg_once = True
+                    f1, f2, f3 = lpc_formants(
+                        frame,
+                        self.cfg.sr,
+                        order=self.cfg.lpc_order,
+                        fmax=self.cfg.formant_max_hz,
+                    )
+            else:
+                f1, f2, f3 = lpc_formants(
+                    frame, self.cfg.sr, order=self.cfg.lpc_order, fmax=self.cfg.formant_max_hz
+                )
 
-        self._update_formants(frame)
+        formant_vals = [f1, f2, f3]
+        for idx, value in enumerate(formant_vals):
+            series = self._formant_history[idx]
+            series.append(float(value) if value and value > 0 else np.nan)
+
+        h1h2_val = np.nan
+        if voiced and f0 > 0:
+            h1h2_val = h1_h2_db(frame, self.cfg.sr, f0)
+        self.harm.update_value(h1h2_val)
+
+        if voiced and (self._cpp_counter % self._cpp_stride == 0):
+            cpp_val = cpp_db(frame, self.cfg.sr)
+            self._last_cpp = cpp_val
+            self.cpp.update_value(cpp_val)
+        elif self._cpp_counter % self._cpp_stride == 0:
+            self._last_cpp = float("nan")
+            self.cpp.update_value(self._last_cpp)
+        self._cpp_counter += 1
+
         self._update_spectrogram()
 
-    def _cents_std_recent(self, n=50):
-        # PitchPanelのリングバッファから直近n点の標準偏差[cent]
+        self._push_log(
+            f0,
+            formant_vals,
+            h1h2_val,
+            self._last_cpp,
+            rms,
+            voiced,
+        )
+
+    def _update_spectrogram(self) -> None:
+        try:
+            S_db, freqs, times = stft_mag_db(
+                self._audio_buffer,
+                self.cfg.sr,
+                n_fft=self._n_fft,
+                hop=max(1, int(round(self.cfg.sr * self.cfg.hop_ms / 1000))),
+                win=self._analysis_window,
+            )
+        except Exception:
+            return
+
+        formants = []
+        for series in self._formant_history:
+            hist = np.array(series, dtype=float)
+            if hist.size < times.size:
+                padded = np.full(times.size, np.nan, dtype=float)
+                padded[-hist.size :] = hist
+                formants.append(padded)
+            else:
+                formants.append(hist[-times.size :])
+
+        self.spectro.update(S_db, freqs, times, tuple(formants))
+
+    def _cents_std_recent(self, n: int = 50) -> Optional[float]:
         buf = self.pitch.buf.copy()
-        # nanを除外
         vals = buf[~np.isnan(buf)]
         if len(vals) < max(5, n // 2):
             return None
@@ -95,39 +260,44 @@ class MainWindow(QMainWindow):
         hz = recent[recent > 0]
         if len(hz) < 5:
             return None
-        # 中央値からのcent変換
         med = np.median(hz)
         cents = 1200 * np.log2(hz / med)
         return float(np.std(cents))
 
-    def _update_formants(self, frame: np.ndarray) -> None:
-        self.frames_buffer.append(frame.copy())
-
-        f1 = f2 = f3 = 0.0
-        use_burg = self.formant_method == "burg"
-        if use_burg:
-            try:
-                f1, f2, f3 = burg_formants_parselmouth(frame, self.sr, fmax=self.formant_max_hz)
-            except Exception:
-                use_burg = False
-
-        if (not use_burg) and (self.formant_method in {"lpc", "burg"}):
-            f1, f2, f3 = lpc_formants(
-                frame, self.sr, order=self.lpc_order, fmax=self.formant_max_hz
-            )
-
-        for idx, value in enumerate((f1, f2, f3)):
-            series = self.formant_history[idx]
-            if value > 0:
-                series.append(float(value))
-            else:
-                series.append(np.nan)
-
-    def _update_spectrogram(self) -> None:
-        if len(self.frames_buffer) < 4:
+    def _push_log(
+        self,
+        f0: float,
+        formants: list[float],
+        h1h2_val: float,
+        cpp_val: float,
+        rms: float,
+        voiced: bool,
+    ) -> None:
+        if self.recorder is None:
             return
+        row = {
+            "timestamp_ns": time.time_ns(),
+            "f0_hz": float(f0) if f0 > 0 else np.nan,
+            "f1_hz": float(formants[0]) if np.isfinite(formants[0]) and formants[0] > 0 else np.nan,
+            "f2_hz": float(formants[1]) if np.isfinite(formants[1]) and formants[1] > 0 else np.nan,
+            "f3_hz": float(formants[2]) if np.isfinite(formants[2]) and formants[2] > 0 else np.nan,
+            "h1_h2_db": float(h1h2_val) if np.isfinite(h1h2_val) else np.nan,
+            "cpp_db": float(cpp_val) if np.isfinite(cpp_val) else np.nan,
+            "rms_db": float(rms),
+            "voiced": bool(voiced),
+            "sr": int(self.cfg.sr),
+            "frame_ms": int(self.cfg.frame_ms),
+            "hop_ms": int(self.cfg.hop_ms),
+            "pitch_min": float(self.cfg.pitch_min),
+            "pitch_max": float(self.cfg.pitch_max),
+            "formant_max_hz": int(self.cfg.formant_max_hz),
+            "lpc_order": int(self.cfg.lpc_order),
+            "formant_method": self.cfg.formant_method,
+        }
+        self.recorder.push(row)
 
-        frames = np.stack(self.frames_buffer, axis=0)
-        S_db, freqs, times = stft_mag_db(frames, self.sr, n_fft=self.n_fft, hop=self.blocksize)
-        formants = [np.asarray(hist, dtype=float) for hist in self.formant_history]
-        self.spectro.update(S_db, freqs, times, formants)
+    def _save_session_settings(self) -> None:
+        if self.recorder.session_dir is None:
+            return
+        settings_path = self.recorder.session_dir / "settings.yaml"
+        save_preset(settings_path, self.cfg)


### PR DESCRIPTION
## Summary
- add AnalyzerConfig persistence helpers and preset-aware controls sidebar
- implement STFT, LPC/burg formants, H1–H2, CPP, VAD, and Parquet logging utilities and wire them into the main window
- enhance visual panels and add targeted tests for new DSP utilities and UI integrations

## Testing
- pytest -q -ra

------
https://chatgpt.com/codex/tasks/task_e_68d400c08f5c832b89b9ca045838104d